### PR TITLE
Fix `is_even` Cargo.toml

### DIFF
--- a/examples/is_even/Cargo.toml
+++ b/examples/is_even/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name = "regex"
+name = "is-even"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-regex = "1.10.3"
 zk_rust_io = { git = "https://github.com/yetanotherco/zkRust.git" }


### PR DESCRIPTION
Renamed accordingly, and removed regex crate dep